### PR TITLE
Resource size to Long

### DIFF
--- a/src/org/ckan/Resource.java
+++ b/src/org/ckan/Resource.java
@@ -22,7 +22,7 @@ public class Resource{
     private String cache_last_updated;
     private String package_id;
     private String webstore_last_updated;
-    private int size;
+    private long size;
     private int position;
     private String resource_type;
     private String last_modified;
@@ -120,11 +120,11 @@ recent: 3
         return webstore_last_updated;
     }
 
-    public void setSize(int size) {
+    public void setSize(long size) {
         this.size = size;
     }
 
-    public int getSize() {
+    public long getSize() {
         return size;
     }
 


### PR DESCRIPTION
When a resource has size upper then 2 GiB the library crashes.
Now the Max size is 8192 Pebibyte